### PR TITLE
[VTT to MD CLI] Implementation Phase 7: Multi-line voice tags and smart unknown speaker filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "clap"
 version = "4.5.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +126,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,10 +166,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "libc"
+version = "0.2.177"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -154,6 +212,12 @@ checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "regex"
@@ -185,6 +249,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +276,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -264,8 +354,18 @@ dependencies = [
  "anyhow",
  "clap",
  "regex",
+ "tempfile",
  "thiserror",
  "unicode-normalization",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -282,3 +382,9 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/README.md
+++ b/README.md
@@ -1,17 +1,83 @@
 # vtt-to-md
 
-A Rust application for converting VTT (WebVTT) files to Markdown format.
+A Rust command-line tool for converting VTT (WebVTT) transcript files from meeting platforms (Microsoft Teams, Zoom, Google Meet) into readable Markdown format with consolidated speaker segments.
+
+## Features
+
+- **Speaker Consolidation**: Merges consecutive cues from the same speaker into coherent paragraphs
+- **Multi-line Voice Tag Support**: Properly handles VTT files with text spanning multiple lines within voice tags
+- **Timestamp Sorting**: Automatically sorts out-of-order cues by timestamp (common in Teams transcripts)
+- **Smart Unknown Speaker Filtering**: Automatically filters out cues without speaker attribution for Teams-style VTT files (those with `<v>` tags). Can be disabled with `--no-filter-unknown`
+- **Flexible Timestamp Modes**: Include no timestamps, first timestamp per speaker turn, or all timestamps
+- **Custom Speaker Labels**: Customize the label for cues without speaker attribution
+
+## Installation
+
+```bash
+cargo install --path .
+```
+
+Or build from source:
+
+```bash
+cargo build --release
+```
+
+## Usage
+
+Basic conversion:
+```bash
+vtt-to-md input.vtt
+```
+
+With options:
+```bash
+vtt-to-md input.vtt output.md --filter-unknown --include-timestamps first
+```
+
+### Command-Line Options
+
+- `INPUT` - Path to the input VTT file (required)
+- `OUTPUT` - Path to the output Markdown file (optional, defaults to INPUT with .md extension)
+- `--force` - Overwrite existing output file
+- `--no-clobber` - Skip conversion if output file exists
+- `--stdout` - Print Markdown to stdout instead of writing to file
+- `--unknown-speaker LABEL` - Custom label for cues without speaker attribution (default: "Unknown")
+- `--filter-unknown` - Explicitly filter out cues without speaker attribution (auto-enabled for Teams-style VTT)
+- `--no-filter-unknown` - Disable automatic filtering for Teams-style VTT files
+- `--include-timestamps MODE` - Timestamp inclusion mode: `none` (default), `first`, or `each`
+
+### Examples
+
+Convert Teams transcript (Unknown speakers automatically filtered):
+```bash
+vtt-to-md "teams-meeting.vtt"
+```
+
+Keep Unknown speakers for Teams transcript:
+```bash
+vtt-to-md "teams-meeting.vtt" --no-filter-unknown
+```
+
+Include first timestamp per speaker turn:
+```bash
+vtt-to-md "meeting.vtt" --include-timestamps first
+```
+
+Output to stdout with custom unknown speaker label:
+```bash
+vtt-to-md "meeting.vtt" --stdout --unknown-speaker "Narrator"
+```
+
+Force overwrite existing file:
+```bash
+vtt-to-md "meeting.vtt" "notes.md" --force
+```
 
 ## Building
 
 ```bash
 cargo build
-```
-
-## Running
-
-```bash
-cargo run
 ```
 
 ## Testing

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,6 +57,22 @@ pub struct Args {
     )]
     pub unknown_speaker: String,
 
+    /// Filter out cues without speaker attribution
+    #[arg(
+        long,
+        help = "Filter out cues without speaker attribution (removes 'Unknown' speaker segments).\n\
+                Auto-enabled for Teams-style VTT files with <v> tags unless explicitly disabled with --no-filter-unknown"
+    )]
+    pub filter_unknown: bool,
+
+    /// Disable automatic filtering of unknown speakers for Teams-style VTT files
+    #[arg(
+        long,
+        conflicts_with = "filter_unknown",
+        help = "Disable automatic filtering of unknown speakers for Teams-style VTT files"
+    )]
+    pub no_filter_unknown: bool,
+
     /// Timestamp inclusion mode
     #[arg(
         long,

--- a/src/consolidator.rs
+++ b/src/consolidator.rs
@@ -434,4 +434,36 @@ mod tests {
         // Test empty input
         assert_eq!(join_texts(&[]), "");
     }
+
+    #[test]
+    fn test_join_texts_mid_sentence_breaks() {
+        // Test text that ends mid-sentence (no terminal punctuation)
+        // and should be joined without space to the next fragment
+        assert_eq!(
+            join_texts(&[
+                "But imagine for the user experience being".to_string(),
+                "you have a prompt that blue like kind of".to_string(),
+            ]),
+            "But imagine for the user experience being you have a prompt that blue like kind of"
+        );
+
+        // Test mixed: some complete sentences, some fragments
+        assert_eq!(
+            join_texts(&[
+                "First sentence.".to_string(),
+                "Fragment without ending".to_string(),
+                "continues here.".to_string(),
+            ]),
+            "First sentence. Fragment without ending continues here."
+        );
+
+        // Test text ending with comma (should join with space)
+        assert_eq!(
+            join_texts(&[
+                "Hello,".to_string(),
+                "how are you?".to_string(),
+            ]),
+            "Hello, how are you?"
+        );
+    }
 }


### PR DESCRIPTION
## Phase 7: Multi-line Voice Tags and Smart Unknown Speaker Filtering

### Objective
Fix critical parsing issues with Teams-style VTT files where text spans multiple lines within voice tags, implement timestamp sorting for out-of-order cues, and add smart detection to automatically filter unknown speakers for Teams format files.

### Changes Made

#### Multi-line Voice Tag Parsing
- Fixed regex patterns in `src/parser.rs` to support multi-line content using `(?s)` DOTALL flag
- Updated three patterns: closed tags with speaker, closed tags without speaker, unclosed tags
- Fixes the bug where text like `<v Speaker>Line 1\nLine 2</v>` was only capturing "Line 1"

#### Timestamp Sorting
- Implemented chronological cue ordering in `src/parser.rs` after parsing
- Handles out-of-order cues common in Teams exports
- Ensures consolidator receives cues in correct time sequence for proper speaker turn grouping

#### Teams Format Detection
- Added `has_voice_tags: bool` field to `VttDocument` struct
- Modified `parse_cues()` to return tuple indicating if voice tags were found
- Detection logic: checks if any parsed cues have `speaker.is_some()`

#### Smart Unknown Speaker Filtering
- Implemented automatic filtering for Teams format files
- Added `--no-filter-unknown` CLI flag to disable auto-filtering
- Updated filtering logic in `main.rs`: filter if `--filter-unknown` OR (Teams format AND NOT `--no-filter-unknown`)
- Updated help text to explain auto-filtering behavior
- Maintains backward compatibility: explicit `--filter-unknown` flag still works

#### Documentation Updates
- Enhanced README.md with smart filtering feature documentation
- Added examples showing Teams auto-detection behavior
- Documented `--no-filter-unknown` flag usage

### Testing
All 46 tests pass (31 unit + 15 integration):
- Added test for multi-line voice tags parsing
- Added test for auto-filtering behavior with Teams format
- Updated existing tests to verify backward compatibility
- No compiler warnings or clippy issues

### Technical Details
- Multi-line regex fix: Changed from `r"<v\s+([^>]*)>(.*?)</v>"` to `r"(?s)<v\s+([^>]*)>(.*?)</v>"`
- Timestamp sorting: Added sort logic after parsing using `cues.sort_by()` with proper None handling
- Auto-detection: `has_voice_tags = cues.iter().any(|cue| cue.speaker.is_some())`
- Smart filtering: `should_filter = args.filter_unknown || (vtt_document.has_voice_tags && !args.no_filter_unknown)`

### Impact
- Eliminates text loss bug that was silently dropping content from multi-line cues
- Improves speaker consolidation accuracy by ensuring chronological cue order
- Dramatically improves Teams user experience - unknown speakers filtered by default
- Maintains full backward compatibility with existing usage patterns

### Related Issue
Part of: https://github.com/lossyrob/vtt-to-md/issues/1

### Implementation Plan
See: `.paw/work/vtt-to-md-cli/ImplementationPlan.md` - Phase 7

🐾 Generated with [PAW](https://github.com/lossyrob/phased-agent-workflow)