### PR TITLE
Add --remove-fillers flag to strip speech disfluencies

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,6 +74,13 @@ pub struct Args {
     )]
     pub no_filter_unknown: bool,
 
+    /// Remove filler words and speech disfluencies from the transcript
+    #[arg(
+        long,
+        help = "Remove filler words and speech disfluencies (uh, um, you know, etc.)"
+    )]
+    pub remove_fillers: bool,
+
     /// Disable auto-increment of output filename on collision
     #[arg(
         long,

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,9 +14,11 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 const ENV_INCLUDE_TIMESTAMPS: &str = "VTT_TO_MD_INCLUDE_TIMESTAMPS";
+const ENV_REMOVE_FILLERS: &str = "VTT_TO_MD_REMOVE_FILLERS";
 const APP_DIR_NAME: &str = "vtt-to-md";
 const CONFIG_FILE_NAME: &str = "config.toml";
 const CONFIG_KEY_INCLUDE_TIMESTAMPS: &str = "include_timestamps";
+const CONFIG_KEY_REMOVE_FILLERS: &str = "remove_fillers";
 
 /// Resolve a configured default `include_timestamps` setting (env var > config file).
 ///
@@ -90,6 +92,97 @@ pub(crate) fn resolve_default_include_timestamps() -> (Option<bool>, Vec<String>
     }
 }
 
+/// Resolve a configured default `remove_fillers` setting (env var > config file).
+///
+/// Only used when the CLI flag `--remove-fillers` was not provided.
+///
+/// Returns a tuple of:
+/// - `Option<bool>`: the configured default, if any
+/// - `Vec<String>`: warnings suitable for printing to stderr
+pub(crate) fn resolve_default_remove_fillers() -> (Option<bool>, Vec<String>) {
+    let mut warnings = Vec::new();
+
+    // 1) Environment variable
+    if let Ok(raw_value) = std::env::var(ENV_REMOVE_FILLERS) {
+        let value = raw_value.trim();
+        if value.is_empty() {
+            warnings.push(format!(
+                "{ENV_REMOVE_FILLERS} is set but empty; ignoring"
+            ));
+        } else {
+            match parse_bool_value(value) {
+                Some(b) => return (Some(b), warnings),
+                None => warnings.push(format!(
+                    "invalid {ENV_REMOVE_FILLERS}='{value}' (expected true/false); ignoring"
+                )),
+            }
+        }
+    }
+
+    // 2) Config file
+    let Some(config_path) = config_file_path() else {
+        return (None, warnings);
+    };
+
+    if !config_path.exists() {
+        return (None, warnings);
+    }
+
+    let contents = match fs::read_to_string(&config_path) {
+        Ok(contents) => contents,
+        Err(err) => {
+            warnings.push(format!(
+                "failed to read config file '{}': {err}; ignoring",
+                config_path.display()
+            ));
+            return (None, warnings);
+        }
+    };
+
+    match parse_config_remove_fillers(&contents) {
+        Ok(value) => (value, warnings),
+        Err(err) => {
+            warnings.push(format!(
+                "invalid config file '{}': {err}; ignoring",
+                config_path.display()
+            ));
+            (None, warnings)
+        }
+    }
+}
+
+fn parse_bool_value(s: &str) -> Option<bool> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "y" | "on" => Some(true),
+        "false" | "0" | "no" | "n" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+fn parse_config_remove_fillers(contents: &str) -> Result<Option<bool>, String> {
+    let value: toml::Value = contents
+        .parse()
+        .map_err(|err| format!("TOML parse error: {err}"))?;
+
+    let Some(rf_value) = value.get(CONFIG_KEY_REMOVE_FILLERS) else {
+        return Ok(None);
+    };
+
+    if let Some(b) = rf_value.as_bool() {
+        return Ok(Some(b));
+    }
+
+    if let Some(s) = rf_value.as_str() {
+        return parse_bool_value(s)
+            .map(|b| Some(b))
+            .ok_or_else(|| format!("invalid {CONFIG_KEY_REMOVE_FILLERS}='{s}' (expected true/false)"));
+    }
+
+    Err(format!(
+        "'{CONFIG_KEY_REMOVE_FILLERS}' must be a boolean or string"
+    ))
+}
+
 fn config_file_path() -> Option<PathBuf> {
     let base_dir = if cfg!(target_os = "windows") {
         std::env::var_os("APPDATA").map(PathBuf::from)
@@ -145,6 +238,7 @@ fn parse_config_include_timestamps(
 #[cfg(test)]
 mod tests {
     use super::parse_config_include_timestamps;
+    use super::parse_config_remove_fillers;
 
     #[test]
     fn parse_config_include_timestamps_missing_key_returns_none() {
@@ -182,5 +276,35 @@ mod tests {
     fn parse_config_include_timestamps_rejects_non_bool_non_string() {
         let contents = "include_timestamps = 123\n";
         assert!(parse_config_include_timestamps(contents).is_err());
+    }
+
+    #[test]
+    fn parse_config_remove_fillers_missing_key_returns_none() {
+        let contents = "other = 'x'\n";
+        assert_eq!(parse_config_remove_fillers(contents).unwrap(), None);
+    }
+
+    #[test]
+    fn parse_config_remove_fillers_accepts_boolean() {
+        let contents = "remove_fillers = true\n";
+        assert_eq!(parse_config_remove_fillers(contents).unwrap(), Some(true));
+
+        let contents = "remove_fillers = false\n";
+        assert_eq!(parse_config_remove_fillers(contents).unwrap(), Some(false));
+    }
+
+    #[test]
+    fn parse_config_remove_fillers_accepts_string_boolean() {
+        let contents = "remove_fillers = \"true\"\n";
+        assert_eq!(parse_config_remove_fillers(contents).unwrap(), Some(true));
+    }
+
+    #[test]
+    fn parse_config_remove_fillers_rejects_invalid() {
+        let contents = "remove_fillers = \"bogus\"\n";
+        assert!(parse_config_remove_fillers(contents).is_err());
+
+        let contents = "remove_fillers = 123\n";
+        assert!(parse_config_remove_fillers(contents).is_err());
     }
 }

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -1,0 +1,330 @@
+//! Filler word and speech disfluency removal.
+//!
+//! This module removes common filler words and speech disfluencies from transcript
+//! text. It handles fillers at the start, middle, and end of sentences, and cleans
+//! up punctuation artifacts left behind after removal.
+
+use regex::Regex;
+
+/// Filler patterns (case-insensitive, word-boundary-delimited).
+///
+/// Extended set includes basic disfluencies plus common discourse markers.
+/// Ambiguous words like "like", "so", "right", "OK" are intentionally excluded.
+const FILLER_PATTERNS: &[&str] = &[
+    // Multi-word phrases (must come before single words)
+    r"uh huh",
+    r"you know",
+    r"i mean",
+    // Single words
+    r"uh",
+    r"um",
+    r"mhm",
+    r"hmm+",
+    r"mm+",
+    r"ah",
+    r"er",
+    r"huh",
+];
+
+/// Remove filler words from the given text.
+///
+/// Handles fillers appearing:
+/// - As the entire text: `"Uh."` → `""`
+/// - At the start: `"Uh, I think"` → `"I think"`
+/// - In the middle: `"on, uh, performance"` → `"on, performance"`
+/// - At the end: `"that's fine, uh"` → `"that's fine"`
+///
+/// Cleans up artifacts: double commas, orphaned punctuation, extra whitespace.
+pub fn remove_fillers(text: &str) -> String {
+    if text.trim().is_empty() {
+        return String::new();
+    }
+
+    // Build a combined regex: match filler words optionally surrounded by
+    // comma+space or just space, with optional trailing period/comma.
+    // Pattern matches: optional leading ", " + filler + optional trailing ","/"."/space
+    let filler_alternation = FILLER_PATTERNS.join("|");
+    let pattern = format!(
+        r"(?i)(?:,\s*)?(?:\b(?:{filler})\b)(?:\s*[,.])?",
+        filler = filler_alternation
+    );
+    let filler_regex = Regex::new(&pattern).unwrap();
+
+    let result = filler_regex.replace_all(text, "");
+
+    // Clean up artifacts
+    let result = cleanup_artifacts(&result);
+
+    result
+}
+
+/// Clean up text artifacts left after filler removal.
+fn cleanup_artifacts(text: &str) -> String {
+    // Collapse multiple spaces
+    let multi_space = Regex::new(r" {2,}").unwrap();
+    let text = multi_space.replace_all(text, " ");
+
+    // Remove orphaned commas: ", ," → ","
+    let double_comma = Regex::new(r",\s*,").unwrap();
+    let text = double_comma.replace_all(&text, ",");
+
+    // Remove leading comma+space at start of text
+    let leading_comma = Regex::new(r"^\s*,\s*").unwrap();
+    let text = leading_comma.replace(&text, "");
+
+    // Remove trailing comma/space at end of text
+    let trailing_comma = Regex::new(r"\s*,\s*$").unwrap();
+    let text = trailing_comma.replace(&text, "");
+
+    let text = text.trim().to_string();
+
+    // Collapse any remaining multiple spaces from chained removals
+    let multi_space = Regex::new(r" {2,}").unwrap();
+    let text = multi_space.replace_all(&text, " ");
+
+    let text = text.trim().to_string();
+
+    // Capitalize after sentence boundaries (". ", "! ", "? ")
+    let text = capitalize_after_sentence_boundaries(&text);
+
+    // Capitalize the very first letter of the text
+    capitalize_first(&text)
+}
+
+/// Capitalize the first letter after each sentence-ending punctuation (. ! ?).
+fn capitalize_after_sentence_boundaries(s: &str) -> String {
+    let re = Regex::new(r"([.!?])\s+([a-z])").unwrap();
+    re.replace_all(s, |caps: &regex::Captures| {
+        format!(
+            "{} {}",
+            &caps[1],
+            caps[2].to_uppercase()
+        )
+    })
+    .to_string()
+}
+
+/// Capitalize the first character, but only if it's a simple lowercase ASCII letter.
+/// Preserves intentional lowercase starts (e.g., "iPhone", "eBay").
+fn capitalize_first(s: &str) -> String {
+    if s.is_empty() {
+        return String::new();
+    }
+
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) if c.is_ascii_lowercase() => {
+            // Only capitalize if the second char is also lowercase or non-alphabetic.
+            // This heuristic preserves camelCase brand names like "iPhone".
+            let rest = chars.as_str();
+            let second_is_upper = rest.chars().next().is_some_and(|c2| c2.is_uppercase());
+            if second_is_upper {
+                // Likely a brand name like "iPhone" — don't capitalize
+                format!("{c}{rest}")
+            } else {
+                let upper: String = c.to_uppercase().collect();
+                upper + rest
+            }
+        }
+        Some(c) => {
+            format!("{c}{}", chars.as_str())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Entire text is filler ---
+
+    #[test]
+    fn test_entire_text_single_filler() {
+        assert_eq!(remove_fillers("Uh."), "");
+        assert_eq!(remove_fillers("Um"), "");
+        assert_eq!(remove_fillers("Mhm."), "");
+        assert_eq!(remove_fillers("Hmm"), "");
+        assert_eq!(remove_fillers("Uh huh."), "");
+    }
+
+    #[test]
+    fn test_entire_text_filler_case_insensitive() {
+        assert_eq!(remove_fillers("UH"), "");
+        assert_eq!(remove_fillers("um."), "");
+        assert_eq!(remove_fillers("MHM"), "");
+    }
+
+    // --- Filler at start of text ---
+
+    #[test]
+    fn test_filler_at_start_with_comma() {
+        assert_eq!(remove_fillers("Uh, I think so"), "I think so");
+        assert_eq!(remove_fillers("Um, that's right"), "That's right");
+    }
+
+    #[test]
+    fn test_filler_at_start_without_comma() {
+        assert_eq!(remove_fillers("Uh I think so"), "I think so");
+    }
+
+    #[test]
+    fn test_multi_word_filler_at_start() {
+        assert_eq!(
+            remove_fillers("You know, it works great"),
+            "It works great"
+        );
+        assert_eq!(
+            remove_fillers("I mean, we should try"),
+            "We should try"
+        );
+    }
+
+    // --- Filler in middle of text ---
+
+    #[test]
+    fn test_filler_mid_sentence() {
+        assert_eq!(
+            remove_fillers("I think, uh, we should go"),
+            "I think we should go"
+        );
+        assert_eq!(
+            remove_fillers("The thing, um, is important"),
+            "The thing is important"
+        );
+    }
+
+    #[test]
+    fn test_multi_word_filler_mid_sentence() {
+        assert_eq!(
+            remove_fillers("It's, you know, pretty good"),
+            "It's pretty good"
+        );
+        assert_eq!(
+            remove_fillers("We could, I mean, try something"),
+            "We could try something"
+        );
+    }
+
+    // --- Filler at end of text ---
+
+    #[test]
+    fn test_filler_at_end() {
+        assert_eq!(remove_fillers("That's fine, uh"), "That's fine");
+        assert_eq!(remove_fillers("That's fine, um."), "That's fine");
+    }
+
+    // --- Multiple fillers ---
+
+    #[test]
+    fn test_multiple_fillers() {
+        assert_eq!(
+            remove_fillers("Uh, I think, um, we should, uh, go"),
+            "I think we should go"
+        );
+    }
+
+    // --- No fillers (should be unchanged) ---
+
+    #[test]
+    fn test_no_fillers_unchanged() {
+        assert_eq!(
+            remove_fillers("Hello, how are you?"),
+            "Hello, how are you?"
+        );
+        assert_eq!(
+            remove_fillers("This is a normal sentence."),
+            "This is a normal sentence."
+        );
+    }
+
+    // --- Fillers should not match inside words ---
+
+    #[test]
+    fn test_filler_word_boundaries() {
+        assert_eq!(remove_fillers("The umbrella is here"), "The umbrella is here");
+        assert_eq!(remove_fillers("Human beings are kind"), "Human beings are kind");
+    }
+
+    // --- Empty/whitespace input ---
+
+    #[test]
+    fn test_empty_input() {
+        assert_eq!(remove_fillers(""), "");
+        assert_eq!(remove_fillers("   "), "");
+    }
+
+    // --- Extended set fillers ---
+
+    #[test]
+    fn test_you_know_i_mean() {
+        assert_eq!(
+            remove_fillers("It's, you know, pretty good"),
+            "It's pretty good"
+        );
+        assert_eq!(
+            remove_fillers("I mean, we should try"),
+            "We should try"
+        );
+    }
+
+    // --- Hmm/mm variants ---
+
+    #[test]
+    fn test_hmm_variants() {
+        assert_eq!(remove_fillers("Hmmm, that's interesting"), "That's interesting");
+        assert_eq!(remove_fillers("Mmm, yes"), "Yes");
+    }
+
+    // --- Capitalize after removal ---
+
+    #[test]
+    fn test_capitalizes_first_letter_after_removal() {
+        assert_eq!(remove_fillers("Uh, it's fine"), "It's fine");
+        assert_eq!(remove_fillers("Um, the thing is"), "The thing is");
+    }
+
+    // --- Real transcript examples ---
+
+    #[test]
+    fn test_real_transcript_example() {
+        assert_eq!(
+            remove_fillers("Mhm. Uh, it it's fine. Uh, working on, uh, you know, performance dashboard."),
+            "It it's fine. Working on performance dashboard."
+        );
+    }
+
+    // --- Sentence boundary capitalization ---
+
+    #[test]
+    fn test_capitalizes_after_sentence_boundary() {
+        assert_eq!(
+            remove_fillers("Done. um, next topic."),
+            "Done. Next topic."
+        );
+    }
+
+    // --- Brand name preservation ---
+
+    #[test]
+    fn test_preserves_brand_name_capitalization() {
+        assert_eq!(
+            remove_fillers("Um, iPhone is great"),
+            "iPhone is great"
+        );
+    }
+
+    // --- "kind of" / "sort of" are NOT removed (legitimate uses) ---
+
+    #[test]
+    fn test_kind_of_sort_of_preserved() {
+        assert_eq!(
+            remove_fillers("What kind of car is it?"),
+            "What kind of car is it?"
+        );
+        assert_eq!(
+            remove_fillers("She sort of agreed"),
+            "She sort of agreed"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod cli;
 mod config;
 mod consolidator;
 mod error;
+mod filler;
 mod markdown;
 mod parser;
 
@@ -47,6 +48,15 @@ fn main() -> ExitCode {
 
     warnings.extend(config_warnings);
 
+    // Resolve effective remove_fillers (CLI > env > config > built-in default)
+    let (configured_remove_fillers, rf_warnings) = if args.remove_fillers {
+        (None, Vec::new())
+    } else {
+        config::resolve_default_remove_fillers()
+    };
+
+    warnings.extend(rf_warnings);
+
     for warning in warnings {
         eprintln!("Warning: {warning}");
     }
@@ -56,8 +66,10 @@ fn main() -> ExitCode {
         .map(|setting| setting.value)
         .unwrap_or(configured_default.unwrap_or(false));
 
+    let effective_remove_fillers = args.remove_fillers || configured_remove_fillers.unwrap_or(false);
+
     // Run the conversion
-    if let Err(e) = run_conversion(&args, effective_include_timestamps) {
+    if let Err(e) = run_conversion(&args, effective_include_timestamps, effective_remove_fillers) {
         eprintln!("Error: {}", e);
         return e.exit_code();
     }
@@ -66,7 +78,11 @@ fn main() -> ExitCode {
 }
 
 /// Run the VTT to Markdown conversion pipeline.
-fn run_conversion(args: &Args, include_timestamps: bool) -> Result<(), error::VttError> {
+fn run_conversion(
+    args: &Args,
+    include_timestamps: bool,
+    remove_fillers: bool,
+) -> Result<(), error::VttError> {
     // Parse the VTT file
     let vtt_document = parser::VttDocument::parse(&args.input)?;
 
@@ -89,6 +105,20 @@ fn run_conversion(args: &Args, include_timestamps: bool) -> Result<(), error::Vt
 
     // Consolidate speaker segments
     let segments = consolidator::consolidate_cues(&cues, &args.unknown_speaker, include_timestamps);
+
+    // Remove filler words if requested
+    let segments = if remove_fillers {
+        segments
+            .into_iter()
+            .map(|mut seg| {
+                seg.text = filler::remove_fillers(&seg.text);
+                seg
+            })
+            .filter(|seg| !seg.text.trim().is_empty())
+            .collect()
+    } else {
+        segments
+    };
 
     // Format as Markdown
     let markdown_content = markdown::format_markdown(&segments, include_timestamps);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -46,6 +46,7 @@ fn new_test_command(vtt_to_md: &PathBuf) -> (Command, TempDir) {
 
     // Ensure tests are not affected by user environment/config.
     cmd.env_remove("VTT_TO_MD_INCLUDE_TIMESTAMPS");
+    cmd.env_remove("VTT_TO_MD_REMOVE_FILLERS");
 
     // Point the per-user config directory at a temp folder.
     #[cfg(target_os = "windows")]
@@ -922,4 +923,228 @@ mod include_timestamps_defaults_windows {
         assert!(stderr.contains("Warning:"));
         assert!(stderr.contains("legacy"));
     }
+}
+
+// ── Remove Fillers Tests ─────────────────────────────────────────────────
+
+const VTT_WITH_FILLERS: &str = "\
+WEBVTT
+
+00:00:00.000 --> 00:00:02.000
+<v Alice>Uh, I think we should start.</v>
+
+00:00:02.000 --> 00:00:04.000
+<v Bob>Mhm.</v>
+
+00:00:04.000 --> 00:00:06.000
+<v Bob>Um, yeah that sounds good.</v>
+
+00:00:06.000 --> 00:00:08.000
+<v Alice>The, uh, performance is, you know, important.</v>
+";
+
+#[test]
+fn test_remove_fillers_flag_removes_fillers() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_path = create_test_vtt(&temp_dir, "fillers.vtt", VTT_WITH_FILLERS);
+
+    let vtt_to_md = get_vtt_to_md_path();
+    let (mut cmd, _config_root) = new_test_command(&vtt_to_md);
+    let output = cmd
+        .arg(input_path.to_str().unwrap())
+        .arg("--stdout")
+        .arg("--remove-fillers")
+        .output()
+        .expect("Failed to execute vtt-to-md");
+
+    assert!(
+        output.status.success(),
+        "Command failed: {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Fillers should be removed
+    assert!(
+        !stdout.contains("Uh,"),
+        "Filler 'Uh' should be removed: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Um,"),
+        "Filler 'Um' should be removed: {stdout}"
+    );
+    assert!(
+        !stdout.contains("you know"),
+        "Filler 'you know' should be removed: {stdout}"
+    );
+
+    // Content should be preserved
+    assert!(
+        stdout.contains("I think we should start"),
+        "Non-filler content should be preserved: {stdout}"
+    );
+    assert!(
+        stdout.contains("sounds good"),
+        "Non-filler content should be preserved: {stdout}"
+    );
+}
+
+#[test]
+fn test_fillers_preserved_without_flag() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_path = create_test_vtt(&temp_dir, "fillers.vtt", VTT_WITH_FILLERS);
+
+    let vtt_to_md = get_vtt_to_md_path();
+    let (mut cmd, _config_root) = new_test_command(&vtt_to_md);
+    let output = cmd
+        .arg(input_path.to_str().unwrap())
+        .arg("--stdout")
+        .output()
+        .expect("Failed to execute vtt-to-md");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Fillers should still be present without the flag
+    assert!(
+        stdout.contains("Uh,"),
+        "Fillers should be preserved without --remove-fillers: {stdout}"
+    );
+    assert!(
+        stdout.contains("you know"),
+        "Fillers should be preserved without --remove-fillers: {stdout}"
+    );
+}
+
+#[test]
+fn test_remove_fillers_drops_empty_turns() {
+    let vtt_content = "\
+WEBVTT
+
+00:00:00.000 --> 00:00:02.000
+<v Alice>Hello there.</v>
+
+00:00:02.000 --> 00:00:04.000
+<v Bob>Uh.</v>
+
+00:00:04.000 --> 00:00:06.000
+<v Bob>Mhm.</v>
+
+00:00:06.000 --> 00:00:08.000
+<v Alice>How are you?</v>
+";
+
+    let temp_dir = TempDir::new().unwrap();
+    let input_path = create_test_vtt(&temp_dir, "empty_turns.vtt", vtt_content);
+
+    let vtt_to_md = get_vtt_to_md_path();
+    let (mut cmd, _config_root) = new_test_command(&vtt_to_md);
+    let output = cmd
+        .arg(input_path.to_str().unwrap())
+        .arg("--stdout")
+        .arg("--remove-fillers")
+        .output()
+        .expect("Failed to execute vtt-to-md");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Bob's turn should be completely removed (was only fillers)
+    assert!(
+        !stdout.contains("**Bob:**"),
+        "Bob's filler-only turn should be removed: {stdout}"
+    );
+
+    // Alice's turns should remain
+    assert!(stdout.contains("**Alice:** Hello there."));
+    assert!(stdout.contains("**Alice:** How are you?"));
+}
+
+#[test]
+fn test_remove_fillers_mid_sentence() {
+    let vtt_content = "\
+WEBVTT
+
+00:00:00.000 --> 00:00:04.000
+<v Alice>The thing is, um, we need to, uh, fix the bug.</v>
+";
+
+    let temp_dir = TempDir::new().unwrap();
+    let input_path = create_test_vtt(&temp_dir, "mid_sentence.vtt", vtt_content);
+
+    let vtt_to_md = get_vtt_to_md_path();
+    let (mut cmd, _config_root) = new_test_command(&vtt_to_md);
+    let output = cmd
+        .arg(input_path.to_str().unwrap())
+        .arg("--stdout")
+        .arg("--remove-fillers")
+        .output()
+        .expect("Failed to execute vtt-to-md");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stdout.contains("um"),
+        "Mid-sentence filler should be removed: {stdout}"
+    );
+    assert!(
+        !stdout.contains("uh"),
+        "Mid-sentence filler should be removed: {stdout}"
+    );
+    assert!(
+        stdout.contains("fix the bug"),
+        "Non-filler content should remain: {stdout}"
+    );
+}
+
+#[test]
+fn test_remove_fillers_env_var() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_path = create_test_vtt(&temp_dir, "fillers.vtt", VTT_WITH_FILLERS);
+
+    let vtt_to_md = get_vtt_to_md_path();
+    let (mut cmd, _config_root) = new_test_command(&vtt_to_md);
+    let output = cmd
+        .env("VTT_TO_MD_REMOVE_FILLERS", "true")
+        .arg(input_path.to_str().unwrap())
+        .arg("--stdout")
+        .output()
+        .expect("Failed to execute vtt-to-md");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Fillers should be removed via env var
+    assert!(
+        !stdout.contains("Uh,"),
+        "Fillers should be removed via env var: {stdout}"
+    );
+}
+
+#[test]
+fn test_remove_fillers_config_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_path = create_test_vtt(&temp_dir, "fillers.vtt", VTT_WITH_FILLERS);
+
+    let vtt_to_md = get_vtt_to_md_path();
+    let (mut cmd, config_root) = new_test_command(&vtt_to_md);
+
+    write_test_config(&config_root, "remove_fillers = true\n");
+
+    let output = cmd
+        .arg(input_path.to_str().unwrap())
+        .arg("--stdout")
+        .output()
+        .expect("Failed to execute vtt-to-md");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Fillers should be removed via config file
+    assert!(
+        !stdout.contains("Uh,"),
+        "Fillers should be removed via config: {stdout}"
+    );
 }


### PR DESCRIPTION
## Summary

Adds a new `--remove-fillers` CLI flag that removes filler words and speech disfluencies from transcript output, improving readability of converted Markdown.

## Filler words removed

**Basic disfluencies:** Uh, Um, Mhm, Hmm, Mm, Ah, Er, Huh, Uh huh

**Discourse markers:** You know, I mean

> "kind of" and "sort of" were intentionally excluded — they have too many legitimate non-filler uses (e.g., "What kind of car?").

## Usage

```bash
# Via CLI flag
vtt-to-md transcript.vtt --remove-fillers

# Via environment variable
VTT_TO_MD_REMOVE_FILLERS=true vtt-to-md transcript.vtt

# Via config.toml
echo 'remove_fillers = true' >> ~/.config/vtt-to-md/config.toml
```

Precedence: CLI flag > env var > config.toml > default (false)

## Behavior

- Fillers are removed after speaker consolidation (applied to full speaker turns)
- Punctuation artifacts are cleaned up (double commas, orphaned spaces)
- Smart capitalization: preserves brand names ("iPhone"), capitalizes after sentence boundaries
- Empty speaker turns (where text was only fillers like "Uh.") are dropped entirely

## Changes

| File | Change |
|------|--------|
| `src/filler.rs` | **New** — regex-based filler removal + 22 unit tests |
| `src/cli.rs` | Added `--remove-fillers` flag |
| `src/config.rs` | Added env var + config.toml support |
| `src/main.rs` | Wired into pipeline after consolidation |
| `tests/integration_test.rs` | 6 new integration tests |

## Tests

All 85 tests pass (60 unit + 25 integration).